### PR TITLE
Add RenewalSuccess model

### DIFF
--- a/src/main/java/io/prowave/chargify/webhook/bean/RenewalSuccess.java
+++ b/src/main/java/io/prowave/chargify/webhook/bean/RenewalSuccess.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016 Prowave Consulting, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.prowave.chargify.webhook.bean;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RenewalSuccess extends Payload {
+}


### PR DESCRIPTION
Though stated in the README that it exists, there's no wrapper for renewal_success webhook event (while the wrapper for renewal_failure does exist). Adding one will simplify handling the renewal_success event and supplement the renewal event wrappers set.