### PR TITLE
Migrate from Java Util Date

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <maven-gpg-plugin>1.6</maven-gpg-plugin>
     <nexus-staging-maven-plugin>1.6.8</nexus-staging-maven-plugin>
     <slf4j>1.7.26</slf4j>
-    <jackson>2.12.7.1</jackson>
+    <jackson>2.17.2</jackson>
     <junit>4.13.1</junit>
     <commons-lang3>3.8.1</commons-lang3>
     <commons-io>2.7</commons-io>
@@ -148,6 +148,16 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <version>${jackson}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>${jackson}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
       <version>${jackson}</version>
     </dependency>
 

--- a/src/main/java/io/prowave/chargify/webhook/OffsetDateTimeDeserializer.java
+++ b/src/main/java/io/prowave/chargify/webhook/OffsetDateTimeDeserializer.java
@@ -1,0 +1,46 @@
+package io.prowave.chargify.webhook;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public class OffsetDateTimeDeserializer extends JsonDeserializer<OffsetDateTime> implements ContextualDeserializer {
+
+    private DateTimeFormatter formatter;
+
+    public OffsetDateTimeDeserializer(DateTimeFormatter formatter) {
+        this.formatter = formatter;
+    }
+
+    @Override
+    public OffsetDateTime deserialize(JsonParser parser, DeserializationContext ctxt) throws IOException {
+        String dateString = parser.getText();
+
+        if (dateString == null || dateString.isEmpty()) {
+            return null;
+        }
+
+        try {
+            return OffsetDateTime.parse(dateString, formatter);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("Failed to parse OffsetDateTime with format: " + formatter, e);
+        }
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) throws JsonMappingException {
+        if (property != null) {
+            JsonFormat.Value format = property.findPropertyFormat(ctxt.getConfig(), OffsetDateTime.class);
+            if (format != null && format.hasPattern()) {
+                this.formatter = DateTimeFormatter.ofPattern(format.getPattern());
+            }
+        }
+        return this;
+    }
+}

--- a/src/main/java/io/prowave/chargify/webhook/bean/BillingDateChange.java
+++ b/src/main/java/io/prowave/chargify/webhook/bean/BillingDateChange.java
@@ -17,14 +17,11 @@
  */
 package io.prowave.chargify.webhook.bean;
 
-import java.util.Date;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BillingDateChange extends Payload {
-	
-	
-	
+
+
+
 }

--- a/src/main/java/io/prowave/chargify/webhook/bean/ComponentAllocationChange.java
+++ b/src/main/java/io/prowave/chargify/webhook/bean/ComponentAllocationChange.java
@@ -19,32 +19,31 @@ package io.prowave.chargify.webhook.bean;
 
 
 
-import java.sql.Timestamp;
-import java.util.Date;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.time.OffsetDateTime;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ComponentAllocationChange extends Payload {
-	
+
 	private Component component;
-	
+
 	private Product product;
-	
+
 	private String memo;
-	
+
 	//2016-12-21T19:55:55Z
-	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss'Z'")
-	private Date timestamp;
-	
+	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ssX")
+	private OffsetDateTime timestamp;
+
 	@JsonProperty("previous_allocation")
 	private Integer previousAllocation;
-	
+
 	@JsonProperty("new_allocation")
 	private Integer newAllocation;
-	
+
 
 	public Component getComponent() {
 		return component;
@@ -70,11 +69,11 @@ public class ComponentAllocationChange extends Payload {
 		this.memo = memo;
 	}
 
-	public Date getTimestamp() {
+	public OffsetDateTime getTimestamp() {
 		return timestamp;
 	}
 
-	public void setTimestamp(Date timestamp) {
+	public void setTimestamp(OffsetDateTime timestamp) {
 		this.timestamp = timestamp;
 	}
 
@@ -94,6 +93,6 @@ public class ComponentAllocationChange extends Payload {
 		this.newAllocation = newAllocation;
 	}
 
-	
-	
+
+
 }

--- a/src/main/java/io/prowave/chargify/webhook/bean/Customer.java
+++ b/src/main/java/io/prowave/chargify/webhook/bean/Customer.java
@@ -17,10 +17,10 @@
  */
 package io.prowave.chargify.webhook.bean;
 
-import java.util.Date;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.OffsetDateTime;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Customer {
@@ -51,19 +51,19 @@ public class Customer {
 	private String lastName;
 
 	@JsonProperty("created_at")
-	private Date createdAt;
+	private OffsetDateTime createdAt;
 
 	@JsonProperty("updated_at")
-	private Date updatedAt;
+	private OffsetDateTime updatedAt;
 
 	@JsonProperty("portal_invite_last_accepted_at")
-	private Date portalInviteLastAcceptedAt;
+	private OffsetDateTime portalInviteLastAcceptedAt;
 
 	@JsonProperty("portal_customer_created_at")
-	private Date portalCustomerCreatedAt;
+	private OffsetDateTime portalCustomerCreatedAt;
 
 	@JsonProperty("portal_invite_last_sent_at")
-	private Date portalInviteLastSentAt;
+	private OffsetDateTime portalInviteLastSentAt;
 
 	@JsonProperty("vat_number")
 	private String vatNumber;
@@ -191,43 +191,43 @@ public class Customer {
 		this.ccEmails = ccEmails;
 	}
 
-	public Date getCreatedAt() {
+	public OffsetDateTime getCreatedAt() {
 		return createdAt;
 	}
 
-	public void setCreatedAt(Date createdAt) {
+	public void setCreatedAt(OffsetDateTime createdAt) {
 		this.createdAt = createdAt;
 	}
 
-	public Date getUpdatedAt() {
+	public OffsetDateTime getUpdatedAt() {
 		return updatedAt;
 	}
 
-	public void setUpdatedAt(Date updatedAt) {
+	public void setUpdatedAt(OffsetDateTime updatedAt) {
 		this.updatedAt = updatedAt;
 	}
 
-	public Date getPortalInviteLastAcceptedAt() {
+	public OffsetDateTime getPortalInviteLastAcceptedAt() {
 		return portalInviteLastAcceptedAt;
 	}
 
-	public void setPortalInviteLastAcceptedAt(Date portalInviteLastAcceptedAt) {
+	public void setPortalInviteLastAcceptedAt(OffsetDateTime portalInviteLastAcceptedAt) {
 		this.portalInviteLastAcceptedAt = portalInviteLastAcceptedAt;
 	}
 
-	public Date getPortalCustomerCreatedAt() {
+	public OffsetDateTime getPortalCustomerCreatedAt() {
 		return portalCustomerCreatedAt;
 	}
 
-	public void setPortalCustomerCreatedAt(Date portalCustomerCreatedAt) {
+	public void setPortalCustomerCreatedAt(OffsetDateTime portalCustomerCreatedAt) {
 		this.portalCustomerCreatedAt = portalCustomerCreatedAt;
 	}
 
-	public Date getPortalInviteLastSentAt() {
+	public OffsetDateTime getPortalInviteLastSentAt() {
 		return portalInviteLastSentAt;
 	}
 
-	public void setPortalInviteLastSentAt(Date portalInviteLastSentAt) {
+	public void setPortalInviteLastSentAt(OffsetDateTime portalInviteLastSentAt) {
 		this.portalInviteLastSentAt = portalInviteLastSentAt;
 	}
 

--- a/src/main/java/io/prowave/chargify/webhook/bean/Dunner.java
+++ b/src/main/java/io/prowave/chargify/webhook/bean/Dunner.java
@@ -17,10 +17,10 @@
  */
 package io.prowave.chargify.webhook.bean;
 
-import java.util.Date;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.OffsetDateTime;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Dunner {
@@ -33,10 +33,10 @@ public class Dunner {
 	private Integer attempts;
 
 	@JsonProperty("last_attempted_at")
-	private Date lastAttemptedAt;
+	private OffsetDateTime lastAttemptedAt;
 
 	@JsonProperty("created_at")
-	private Date createdAt;
+	private OffsetDateTime createdAt;
 
 	@JsonProperty("revenue_at_risk_in_cents")
 	private String revenueAtRiskInCents;
@@ -65,19 +65,19 @@ public class Dunner {
 		this.attempts = attempts;
 	}
 
-	public Date getLastAttemptedAt() {
+	public OffsetDateTime getLastAttemptedAt() {
 		return lastAttemptedAt;
 	}
 
-	public void setLastAttemptedAt(Date lastAttemptedAt) {
+	public void setLastAttemptedAt(OffsetDateTime lastAttemptedAt) {
 		this.lastAttemptedAt = lastAttemptedAt;
 	}
 
-	public Date getCreatedAt() {
+	public OffsetDateTime getCreatedAt() {
 		return createdAt;
 	}
 
-	public void setCreatedAt(Date createdAt) {
+	public void setCreatedAt(OffsetDateTime createdAt) {
 		this.createdAt = createdAt;
 	}
 
@@ -89,6 +89,6 @@ public class Dunner {
 		this.revenueAtRiskInCents = revenueAtRiskInCents;
 	}
 
-	
+
 
 }

--- a/src/main/java/io/prowave/chargify/webhook/bean/Product.java
+++ b/src/main/java/io/prowave/chargify/webhook/bean/Product.java
@@ -17,10 +17,10 @@
  */
 package io.prowave.chargify.webhook.bean;
 
-import java.util.Date;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.OffsetDateTime;
 
 @JsonIgnoreProperties(value = { "public_signup_pages" }, ignoreUnknown = true)
 public class Product {
@@ -51,13 +51,13 @@ public class Product {
   private String expirationIntervalUnit;
 
   @JsonProperty("created_at")
-  private Date createdAt;
+  private OffsetDateTime createdAt;
 
   @JsonProperty("updated_at")
-  private Date updatedAt;
+  private OffsetDateTime updatedAt;
 
   @JsonProperty("archived_at")
-  private Date archivedAt;
+  private OffsetDateTime archivedAt;
 
   @JsonProperty("return_params")
   private String returnParams;
@@ -197,27 +197,27 @@ public class Product {
     this.expirationIntervalUnit = expirationIntervalUnit;
   }
 
-  public Date getCreatedAt() {
+  public OffsetDateTime getCreatedAt() {
     return createdAt;
   }
 
-  public void setCreatedAt(Date createdAt) {
+  public void setCreatedAt(OffsetDateTime createdAt) {
     this.createdAt = createdAt;
   }
 
-  public Date getUpdatedAt() {
+  public OffsetDateTime getUpdatedAt() {
     return updatedAt;
   }
 
-  public void setUpdatedAt(Date updatedAt) {
+  public void setUpdatedAt(OffsetDateTime updatedAt) {
     this.updatedAt = updatedAt;
   }
 
-  public Date getArchivedAt() {
+  public OffsetDateTime getArchivedAt() {
     return archivedAt;
   }
 
-  public void setArchivedAt(Date archivedAt) {
+  public void setArchivedAt(OffsetDateTime archivedAt) {
     this.archivedAt = archivedAt;
   }
 

--- a/src/main/java/io/prowave/chargify/webhook/bean/Statement.java
+++ b/src/main/java/io/prowave/chargify/webhook/bean/Statement.java
@@ -17,10 +17,10 @@
  */
 package io.prowave.chargify.webhook.bean;
 
-import java.util.Date;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.OffsetDateTime;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Statement {
@@ -31,22 +31,22 @@ public class Statement {
 	private Long subscriptionId;
 
 	@JsonProperty("opened_at")
-	private Date openedAt;
+	private OffsetDateTime openedAt;
 
 	@JsonProperty("total_in_cents")
 	private Long totalInCents;
 
 	@JsonProperty("closed_at")
-	private Date closedAt;
+	private OffsetDateTime closedAt;
 
 	@JsonProperty("updated_at")
-	private Date updatedAt;
+	private OffsetDateTime updatedAt;
 
 	@JsonProperty("created_at")
-	private Date createdAt;
+	private OffsetDateTime createdAt;
 
 	@JsonProperty("settled_at")
-	private Date settledAt;
+	private OffsetDateTime settledAt;
 
 	private String memo;
 
@@ -66,11 +66,11 @@ public class Statement {
 		this.subscriptionId = subscriptionId;
 	}
 
-	public Date getOpenedAt() {
+	public OffsetDateTime getOpenedAt() {
 		return openedAt;
 	}
 
-	public void setOpenedAt(Date openedAt) {
+	public void setOpenedAt(OffsetDateTime openedAt) {
 		this.openedAt = openedAt;
 	}
 
@@ -90,35 +90,35 @@ public class Statement {
 		this.totalInCents = totalInCents;
 	}
 
-	public Date getClosedAt() {
+	public OffsetDateTime getClosedAt() {
 		return closedAt;
 	}
 
-	public void setClosedAt(Date closedAt) {
+	public void setClosedAt(OffsetDateTime closedAt) {
 		this.closedAt = closedAt;
 	}
 
-	public Date getUpdatedAt() {
+	public OffsetDateTime getUpdatedAt() {
 		return updatedAt;
 	}
 
-	public void setUpdatedAt(Date updatedAt) {
+	public void setUpdatedAt(OffsetDateTime updatedAt) {
 		this.updatedAt = updatedAt;
 	}
 
-	public Date getCreatedAt() {
+	public OffsetDateTime getCreatedAt() {
 		return createdAt;
 	}
 
-	public void setCreatedAt(Date createdAt) {
+	public void setCreatedAt(OffsetDateTime createdAt) {
 		this.createdAt = createdAt;
 	}
 
-	public Date getSettledAt() {
+	public OffsetDateTime getSettledAt() {
 		return settledAt;
 	}
 
-	public void setSettledAt(Date settledAt) {
+	public void setSettledAt(OffsetDateTime settledAt) {
 		this.settledAt = settledAt;
 	}
 

--- a/src/main/java/io/prowave/chargify/webhook/bean/Subscription.java
+++ b/src/main/java/io/prowave/chargify/webhook/bean/Subscription.java
@@ -17,7 +17,7 @@
  */
 package io.prowave.chargify.webhook.bean;
 
-import java.util.Date;
+import java.time.OffsetDateTime;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,37 +37,37 @@ public class Subscription {
 	private Long balanceInCents;
 
 	@JsonProperty("activated_at")
-	private Date activatedAt;
+	private OffsetDateTime activatedAt;
 
 	@JsonProperty("trial_started_at")
-	private Date trialStartedAt;
+	private OffsetDateTime trialStartedAt;
 
 	@JsonProperty("trial_ended_at")
-	private Date trialEndedAt;
+	private OffsetDateTime trialEndedAt;
 
 	@JsonProperty("expires_at")
-	private Date expiresAt;
+	private OffsetDateTime expiresAt;
 
 	@JsonProperty("canceled_at")
-	private Date cancelledAt;
+	private OffsetDateTime cancelledAt;
 
 	@JsonProperty("delayed_cancel_at")
-	private Date delayedCancelAt;
+	private OffsetDateTime delayedCancelAt;
 
 	@JsonProperty("created_at")
-	private Date createdAt;
+	private OffsetDateTime createdAt;
 
 	@JsonProperty("updated_at")
-	private Date updatedAt;
+	private OffsetDateTime updatedAt;
 
 	@JsonProperty("next_assessment_at")
-	private Date nextAssessmentAt;
+	private OffsetDateTime nextAssessmentAt;
 
 	@JsonProperty("current_period_started_at")
-	private Date currentPeriodStartedAt;
+	private OffsetDateTime currentPeriodStartedAt;
 
 	@JsonProperty("current_period_ends_at")
-	private Date currentPeriodEndsAt;
+	private OffsetDateTime currentPeriodEndsAt;
 
 	@JsonProperty("payment_collection_method")
 	private String paymentCollectionMethod;
@@ -115,13 +115,13 @@ public class Subscription {
 	private Integer productVersionNumber;
 
 	@JsonProperty("previous_expires_at")
-	private Date previousExpiresAt;
+	private OffsetDateTime previousExpiresAt;
 
 	@JsonProperty("previous_billing_date")
-	private Date previousBillingDate;
+	private OffsetDateTime previousBillingDate;
 
-	
-	
+
+
 	public Long getId() {
 		return id;
 	}
@@ -170,91 +170,91 @@ public class Subscription {
 		this.balanceInCents = balanceInCents;
 	}
 
-	public Date getActivatedAt() {
+	public OffsetDateTime getActivatedAt() {
 		return activatedAt;
 	}
 
-	public void setActivatedAt(Date activatedAt) {
+	public void setActivatedAt(OffsetDateTime activatedAt) {
 		this.activatedAt = activatedAt;
 	}
 
-	public Date getTrialStartedAt() {
+	public OffsetDateTime getTrialStartedAt() {
 		return trialStartedAt;
 	}
 
-	public void setTrialStartedAt(Date trialStartedAt) {
+	public void setTrialStartedAt(OffsetDateTime trialStartedAt) {
 		this.trialStartedAt = trialStartedAt;
 	}
 
-	public Date getTrialEndedAt() {
+	public OffsetDateTime getTrialEndedAt() {
 		return trialEndedAt;
 	}
 
-	public void setTrialEndedAt(Date trialEndedAt) {
+	public void setTrialEndedAt(OffsetDateTime trialEndedAt) {
 		this.trialEndedAt = trialEndedAt;
 	}
 
-	public Date getExpiresAt() {
+	public OffsetDateTime getExpiresAt() {
 		return expiresAt;
 	}
 
-	public void setExpiresAt(Date expiresAt) {
+	public void setExpiresAt(OffsetDateTime expiresAt) {
 		this.expiresAt = expiresAt;
 	}
 
-	public Date getCancelledAt() {
+	public OffsetDateTime getCancelledAt() {
 		return cancelledAt;
 	}
 
-	public void setCancelledAt(Date cancelledAt) {
+	public void setCancelledAt(OffsetDateTime cancelledAt) {
 		this.cancelledAt = cancelledAt;
 	}
 
-	public Date getDelayedCancelAt() {
+	public OffsetDateTime getDelayedCancelAt() {
 		return delayedCancelAt;
 	}
 
-	public void setDelayedCancelAt(Date delayedCancelAt) {
+	public void setDelayedCancelAt(OffsetDateTime delayedCancelAt) {
 		this.delayedCancelAt = delayedCancelAt;
 	}
 
-	public Date getCreatedAt() {
+	public OffsetDateTime getCreatedAt() {
 		return createdAt;
 	}
 
-	public void setCreatedAt(Date createdAt) {
+	public void setCreatedAt(OffsetDateTime createdAt) {
 		this.createdAt = createdAt;
 	}
 
-	public Date getUpdatedAt() {
+	public OffsetDateTime getUpdatedAt() {
 		return updatedAt;
 	}
 
-	public void setUpdatedAt(Date updatedAt) {
+	public void setUpdatedAt(OffsetDateTime updatedAt) {
 		this.updatedAt = updatedAt;
 	}
 
-	public Date getNextAssessmentAt() {
+	public OffsetDateTime getNextAssessmentAt() {
 		return nextAssessmentAt;
 	}
 
-	public void setNextAssessmentAt(Date nextAssessmentAt) {
+	public void setNextAssessmentAt(OffsetDateTime nextAssessmentAt) {
 		this.nextAssessmentAt = nextAssessmentAt;
 	}
 
-	public Date getCurrentPeriodStartedAt() {
+	public OffsetDateTime getCurrentPeriodStartedAt() {
 		return currentPeriodStartedAt;
 	}
 
-	public void setCurrentPeriodStartedAt(Date currentPeriodStartedAt) {
+	public void setCurrentPeriodStartedAt(OffsetDateTime currentPeriodStartedAt) {
 		this.currentPeriodStartedAt = currentPeriodStartedAt;
 	}
 
-	public Date getCurrentPeriodEndsAt() {
+	public OffsetDateTime getCurrentPeriodEndsAt() {
 		return currentPeriodEndsAt;
 	}
 
-	public void setCurrentPeriodEndsAt(Date currentPeriodEndsAt) {
+	public void setCurrentPeriodEndsAt(OffsetDateTime currentPeriodEndsAt) {
 		this.currentPeriodEndsAt = currentPeriodEndsAt;
 	}
 
@@ -330,11 +330,11 @@ public class Subscription {
 		this.previousState = previousState;
 	}
 
-	public Date getPreviousExpiresAt() {
+	public OffsetDateTime getPreviousExpiresAt() {
 		return previousExpiresAt;
 	}
 
-	public void setPreviousExpiresAt(Date previousExpiresAt) {
+	public void setPreviousExpiresAt(OffsetDateTime previousExpiresAt) {
 		this.previousExpiresAt = previousExpiresAt;
 	}
 	public String getCouponCode() {
@@ -384,12 +384,12 @@ public class Subscription {
 	public void setProductVersionNumber(Integer productVersionNumber) {
 		this.productVersionNumber = productVersionNumber;
 	}
-	
-	public Date getPreviousBillingDate() {
+
+	public OffsetDateTime getPreviousBillingDate() {
 		return previousBillingDate;
 	}
 
-	public void setPreviousBillingDate(Date previousBillingDate) {
+	public void setPreviousBillingDate(OffsetDateTime previousBillingDate) {
 		this.previousBillingDate = previousBillingDate;
 	}
 

--- a/src/main/java/io/prowave/chargify/webhook/bean/Transaction.java
+++ b/src/main/java/io/prowave/chargify/webhook/bean/Transaction.java
@@ -17,10 +17,10 @@
  */
 package io.prowave.chargify.webhook.bean;
 
-import java.util.Date;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.OffsetDateTime;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Transaction {
@@ -32,7 +32,7 @@ public class Transaction {
 	private Boolean success;
 
 	@JsonProperty("created_at")
-	private Date createAt;
+	private OffsetDateTime createAt;
 
 	@JsonProperty("transaction_type")
 	private String transactionType;
@@ -137,11 +137,11 @@ public class Transaction {
 		this.success = success;
 	}
 
-	public Date getCreateAt() {
+	public OffsetDateTime getCreateAt() {
 		return createAt;
 	}
 
-	public void setCreateAt(Date createAt) {
+	public void setCreateAt(OffsetDateTime createAt) {
 		this.createAt = createAt;
 	}
 

--- a/src/main/java/io/prowave/chargify/webhook/bean/UpcomingRenewalNotice.java
+++ b/src/main/java/io/prowave/chargify/webhook/bean/UpcomingRenewalNotice.java
@@ -19,12 +19,9 @@ package io.prowave.chargify.webhook.bean;
 
 
 
-import java.util.Date;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class UpcomingRenewalNotice extends Notice {
-	
+
 }

--- a/src/test/java/io/prowave/chargify/webhook/ChargifyConvertProcessorTest.java
+++ b/src/test/java/io/prowave/chargify/webhook/ChargifyConvertProcessorTest.java
@@ -3,15 +3,13 @@ package io.prowave.chargify.webhook;
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.time.DateFormatUtils;
 import org.junit.Test;
 
 
-import io.prowave.chargify.webhook.ChargifyEvent;
-import io.prowave.chargify.webhook.ChargifyWebhook;
-import io.prowave.chargify.webhook.ChargifyWebhookParser;
 import io.prowave.chargify.webhook.bean.BillingDateChange;
 import io.prowave.chargify.webhook.bean.ComponentAllocationChange;
 import io.prowave.chargify.webhook.bean.CustomerUpdate;
@@ -20,7 +18,6 @@ import io.prowave.chargify.webhook.bean.ExpirationDateChange;
 import io.prowave.chargify.webhook.bean.ExpiringCard;
 import io.prowave.chargify.webhook.bean.Payload;
 import io.prowave.chargify.webhook.bean.PaymentFailure;
-import io.prowave.chargify.webhook.bean.PaymentSuccess;
 import io.prowave.chargify.webhook.bean.RenewalFailure;
 import io.prowave.chargify.webhook.bean.SignupFailure;
 import io.prowave.chargify.webhook.bean.Subscription;
@@ -32,136 +29,137 @@ import io.prowave.chargify.webhook.bean.UpgradeDownGradeFailure;
 import io.prowave.chargify.webhook.bean.UpgradeDownGradeSuccess;
 
 public class ChargifyConvertProcessorTest {
+	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss").withZone(ZoneOffset.UTC);
 
 	@Test
 	public void shouldReadBillingDateChange() throws Exception {
-		
+
 		BillingDateChange c = (BillingDateChange) process("./src/test/resources/samples/webhook_billing_date_change.txt", ChargifyEvent.BILLING_DATE_CHANGE);
-		
+
 		assertNotNull(c);
-		assertEquals("2012-10-01 03:49:43",DateFormatUtils.formatUTC(c.getSubscription().getPreviousBillingDate(), "yyyy-MM-dd hh:mm:ss"));
-		
+		assertEquals("2012-10-01 03:49:43", c.getSubscription().getPreviousBillingDate().format(formatter));
+
 
 	}
-	
+
 	@Test
 	public void shouldReadCompAllocChanged() throws Exception {
-		
+
 		ComponentAllocationChange c = (ComponentAllocationChange) process("./src/test/resources/samples/webhook_comp_alloc_change.txt", ChargifyEvent.COMPONENT_ALLOCATION_CHANGE);
-		
+
 		assertNotNull(c);
 		assertEquals(Integer.valueOf(3), c.getNewAllocation());
 		assertEquals(Integer.valueOf(0), c.getPreviousAllocation());
 
 	}
-	
+
 	@Test
 	public void shouldReadCustomerUpdate() throws Exception {
-		
+
 		CustomerUpdate c = (CustomerUpdate) process("./src/test/resources/samples/webhook_customer_update.txt", ChargifyEvent.CUSTOMER_UPDATE);
-		
+
 		assertNotNull(c);
-		assertEquals("2012-09-09 03:38:32",DateFormatUtils.formatUTC(c.getCustomer().getUpdatedAt(), "yyyy-MM-dd hh:mm:ss"));
-	
+		assertEquals("2012-09-09 03:38:32", c.getCustomer().getUpdatedAt().format(formatter));
+
 		try{
 			c.setSubscription(new Subscription());
 			fail();
 		}catch(UnsupportedOperationException ns){
-			
+
 		}
 
 	}
-	
+
 	@Test
 	public void shouldReadDunningStepReached() throws Exception {
-		
+
 		DunningStepReached c = (DunningStepReached) process("./src/test/resources/samples/webhook_dunning_step_reached.txt", ChargifyEvent.DUNNING_STEP_REACHED);
-		
+
 		assertNotNull(c);
 		assertEquals(Integer.valueOf(1), c.getCurrentStep().getDayThreshold());
 		assertEquals(Integer.valueOf(2), c.getNextStep().getDayThreshold());
-		assertEquals("2016-12-20 06:55:55",DateFormatUtils.formatUTC(c.getDunner().getLastAttemptedAt(), "yyyy-MM-dd hh:mm:ss"));
+		assertEquals("2016-12-20 06:55:55", c.getDunner().getLastAttemptedAt().format(formatter));
 
 	}
-	
+
 	@Test
 	public void shouldReadExpirationDateChange() throws Exception {
-		
+
 		ExpirationDateChange c = (ExpirationDateChange) process("./src/test/resources/samples/webhook_expiration_date_change.txt", ChargifyEvent.EXPIRATION_DATE_CHANGE);
-		
+
 		assertNotNull(c);
-		
-		assertEquals("2022-06-14 03:49:43",DateFormatUtils.formatUTC(c.getSubscription().getPreviousExpiresAt(), "yyyy-MM-dd hh:mm:ss"));
+		assertEquals("2022-06-14 03:49:43", c.getSubscription().getPreviousExpiresAt().format(formatter));
+
 		assertNull(c.getSubscription().getExpiresAt());
 
 	}
-	
+
 	@Test
 	public void shouldReadExpiringCard() throws Exception {
-		
+
 		ExpiringCard c = (ExpiringCard) process("./src/test/resources/samples/webhook_expiring_card.txt", ChargifyEvent.EXPIRING_CARD);
-		
+
 		assertNotNull(c);
 		assertEquals("2016",c.getSubscription().getCreditCard().getExpirationYear());
 		assertEquals("4",c.getSubscription().getCreditCard().getExpirationMonth());
 	}
-	
+
 	@Test
 	public void shouldReadPaymentFailure() throws Exception {
-		
+
 		PaymentFailure c = (PaymentFailure) process("./src/test/resources/samples/webhook_payment_failure.txt", ChargifyEvent.PAYMENT_FAILURE);
-		
+
 		assertNotNull(c);
 		assertEquals(false,c.getTransaction().getSuccess());
-		
+
 	}
-	
+
 	@Test
 	public void shouldReadRenewalFailure() throws Exception {
-		
+
 		RenewalFailure c = (RenewalFailure) process("./src/test/resources/samples/webhook_renewal_failure.txt", ChargifyEvent.RENEWAL_FAILURE);
-		
+
 		assertNotNull(c);
 		assertEquals("active",c.getSubscription().getState());
-		
+
 	}
-	
+
 	@Test
 	public void shouldReadSignupFail() throws Exception {
-		
+
 		SignupFailure c = (SignupFailure) process("./src/test/resources/samples/webhook_signup_fail.txt", ChargifyEvent.SIGNUP_FAILURE);
-		
+
 		assertNotNull(c);
 		assertEquals("failed_to_create",c.getSubscription().getState());
-		
+
 	}
-	
+
 	@Test
 	public void shouldReadSubProductChange() throws Exception {
-		
+
 		SubscriptionProductChange c = (SubscriptionProductChange) process("./src/test/resources/samples/webhook_sub_product_change.txt", ChargifyEvent.SUBSCRIPTION_PRODUCT_CHANGE);
-		
+
 		assertNotNull(c);
 		assertEquals("handle_6a9273b8a",c.getPreviousProduct().getHandle());
-		
+
 	}
-	
+
 	@Test
 	public void shouldReadSubStateChange() throws Exception {
-		
+
 		SubscriptionStateChange c = (SubscriptionStateChange) process("./src/test/resources/samples/webhook_sub_state_change.txt", ChargifyEvent.SUBSCRIPTION_STATE_CHANGE);
-		
+
 		assertNotNull(c);
 		assertEquals("active",c.getSubscription().getPreviousState());
 		assertEquals("inactive",c.getSubscription().getState());
-		
+
 	}
-	
+
 	@Test
 	public void shouldReadTrialEndNotice() throws Exception {
-		
+
 		TrialEndNotice c = (TrialEndNotice) process("./src/test/resources/samples/webhook_trial_end_notice.txt", ChargifyEvent.TRIAL_END_NOTICE);
-		
+
 		assertNotNull(c);
 		assertEquals("john@example.com",c.getCustomer().getEmail());
 		assertEquals("Jane",c.getPaymentProfile().getFirstName());
@@ -170,12 +168,12 @@ public class ChargifyConvertProcessorTest {
 		assertEquals("Pro",c.getProduct().getName());
 		assertEquals("active",c.getSubscription().getState());
 	}
-	
+
 	@Test
 	public void shouldReadUpcomingRenewalNotice() throws Exception {
-		
+
 		UpcomingRenewalNotice c = (UpcomingRenewalNotice) process("./src/test/resources/samples/webhook_upcoming_renewal.txt", ChargifyEvent.UPCOMING_RENEWAL_NOTICE);
-		
+
 		assertNotNull(c);
 		assertEquals("john@example.com",c.getCustomer().getEmail());
 		assertEquals("Jane",c.getPaymentProfile().getFirstName());
@@ -184,33 +182,33 @@ public class ChargifyConvertProcessorTest {
 		assertEquals("Pro",c.getProduct().getName());
 		assertEquals("active",c.getSubscription().getState());
 	}
-	
+
 	@Test
 	public void shouldReadUpgradeDowngradeFailure() throws Exception {
-		
+
 		UpgradeDownGradeFailure c = (UpgradeDownGradeFailure) process("./src/test/resources/samples/webhook_upgrade_downgrade_failure.txt", ChargifyEvent.UPGRADE_DOWNGRADE_FAILURE);
-		
+
 		assertNotNull(c);
 		assertEquals("handle_6a9273b8a",  c.getTargetProduct().getHandle());
 		assertEquals("active",c.getSubscription().getState());
 	}
-	
+
 	@Test
 	public void shouldReadUpgradeDowngradeSuccess() throws Exception {
-		
+
 		UpgradeDownGradeSuccess c = (UpgradeDownGradeSuccess) process("./src/test/resources/samples/webhook_upgrade_downgrade_success.txt", ChargifyEvent.UPGRADE_DOWNGRADE_SUCCESS);
-		
+
 		assertNotNull(c);
 		assertEquals("handle_6a9273b8a",  c.getPreviousProduct().getHandle());
 		assertEquals("active",c.getSubscription().getState());
 	}
 
 	private Payload process(String sample, ChargifyEvent type) throws Exception{
-		
+
 		String body = FileUtils.readFileToString(new File(sample));
 		ChargifyWebhook chargifyWebhook = ChargifyWebhookParser.parse(body);
 		Class<? extends Payload> clazz = null;
-		
+
 		switch (type) {
 		case DUNNING_STEP_REACHED :
 			clazz=DunningStepReached.class;
@@ -260,14 +258,14 @@ public class ChargifyConvertProcessorTest {
 		case EXPIRATION_DATE_CHANGE :
 			clazz=ExpirationDateChange.class;
 			break;
-		
+
 		default:
-			
+
 			break;
-		} 
-			
+		}
+
 		Payload payload = ChargifyMessageFactory.createChargifyMessage(chargifyWebhook.getPayload(), clazz);
-		
+
 		return payload;
 	}
 }


### PR DESCRIPTION
Refactored code to replace `java.util.Date` with the modern `java.time` API.

**Note: This is a breaking change (ie for example `getPreviousBillingDate` has a different return type now).**